### PR TITLE
Fix config load order to fix sp crash & run in singleplayer

### DIFF
--- a/src/main/java/com/github/cpburnz/minecraft_prometheus_exporter/PrometheusExporterMod.java
+++ b/src/main/java/com/github/cpburnz/minecraft_prometheus_exporter/PrometheusExporterMod.java
@@ -150,14 +150,14 @@ public class PrometheusExporterMod {
      */
     @Mod.EventHandler
     public void onPreInitialization(FMLPreInitializationEvent event) {
-        if (event.getSide() == Side.CLIENT) return;
-
         // Register the server config.
         try {
             ConfigurationManager.registerConfig(ExporterConfig.class);
         } catch (ConfigException e) {
             throw new RuntimeException(e);
         }
+        
+        if (event.getSide() == Side.CLIENT) return;
 
         // Register event handlers.
         FMLCommonHandler.instance()

--- a/src/main/java/com/github/cpburnz/minecraft_prometheus_exporter/PrometheusExporterMod.java
+++ b/src/main/java/com/github/cpburnz/minecraft_prometheus_exporter/PrometheusExporterMod.java
@@ -156,7 +156,7 @@ public class PrometheusExporterMod {
         } catch (ConfigException e) {
             throw new RuntimeException(e);
         }
-        
+
         if (event.getSide() == Side.CLIENT) return;
 
         // Register event handlers.
@@ -189,7 +189,9 @@ public class PrometheusExporterMod {
      */
     @Mod.EventHandler
     public void onServerStarted(FMLServerStartedEvent event) throws IOException {
-        this.startExporter();
+        if (event.getSide().isServer()) {
+            this.startExporter();
+        }
     }
 
     /**
@@ -199,7 +201,9 @@ public class PrometheusExporterMod {
      */
     @Mod.EventHandler
     public void onServerStopped(FMLServerStoppedEvent event) {
-        this.stopExporter();
+        if (this.is_running) {
+            this.stopExporter();
+        }
         this.mc_server = null;
     }
 

--- a/src/main/java/com/github/cpburnz/minecraft_prometheus_exporter/PrometheusExporterMod.java
+++ b/src/main/java/com/github/cpburnz/minecraft_prometheus_exporter/PrometheusExporterMod.java
@@ -189,7 +189,8 @@ public class PrometheusExporterMod {
      */
     @Mod.EventHandler
     public void onServerStarted(FMLServerStartedEvent event) throws IOException {
-        if (event.getSide().isServer()) {
+        if (event.getSide()
+            .isServer()) {
             this.startExporter();
         }
     }

--- a/src/main/java/com/github/cpburnz/minecraft_prometheus_exporter/collectors/Ticks.java
+++ b/src/main/java/com/github/cpburnz/minecraft_prometheus_exporter/collectors/Ticks.java
@@ -6,6 +6,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.Nullable;
 
+import cpw.mods.fml.common.Mod;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.WorldProvider;
 
@@ -50,6 +51,8 @@ public class Ticks extends BaseCollector {
      */
     private final ConcurrentHashMap.KeySetView<Integer, Boolean> dims_have_ticked;
 
+    private boolean server_has_ticked;
+
     /**
      * The histogram buckets to use for ticks.
      */
@@ -58,6 +61,7 @@ public class Ticks extends BaseCollector {
     public Ticks(MinecraftServer mc_server) {
         super(mc_server);
         this.dims_have_ticked = ConcurrentHashMap.newKeySet(3);
+        server_has_ticked = false;
 
         // Setup server metrics.
         this.server_tick_seconds = Histogram.build()
@@ -200,6 +204,7 @@ public class Ticks extends BaseCollector {
         }
 
         this.server_tick_timer = this.server_tick_seconds.startTimer();
+        server_has_ticked = true;
     }
 
     /**
@@ -207,20 +212,28 @@ public class Ticks extends BaseCollector {
      */
     public void stopServerTick() {
         if (this.server_tick_timer == null) {
+            if (!server_has_ticked) {
+                // WARNING: After restarting the collector, we may start during a
+                // server tick. Do not fail in this scenario.
+                return;
+            }
             throw new IllegalStateException("Server tick stopped without an active tick.");
         }
 
         server_tick_timer.observeDuration();
         this.server_tick_timer = null;
+        server_has_ticked = false;
     }
 
     @SubscribeEvent
     public static void onServerTick(TickEvent.ServerTickEvent event) {
-        // Record server tick.
-        if (event.phase == TickEvent.Phase.START) {
-            Instance.startServerTick();
-        } else if (event.phase == TickEvent.Phase.END) {
-            Instance.stopServerTick();
+        if (Instance != null) {
+            // Record server tick.
+            if (event.phase == TickEvent.Phase.START) {
+                Instance.startServerTick();
+            } else if (event.phase == TickEvent.Phase.END) {
+                Instance.stopServerTick();
+            }
         }
     }
 
@@ -231,12 +244,14 @@ public class Ticks extends BaseCollector {
      */
     @SubscribeEvent
     public static void onDimensionTick(TickEvent.WorldTickEvent event) {
-        // Record dimension tick.
-        WorldProvider dim = event.world.provider;
-        if (event.phase == TickEvent.Phase.START) {
-            Instance.startDimensionTick(dim);
-        } else if (event.phase == TickEvent.Phase.END) {
-            Instance.stopDimensionTick(dim);
+        if (Instance != null) {
+            // Record dimension tick.
+            WorldProvider dim = event.world.provider;
+            if (event.phase == TickEvent.Phase.START) {
+                Instance.startDimensionTick(dim);
+            } else if (event.phase == TickEvent.Phase.END) {
+                Instance.stopDimensionTick(dim);
+            }
         }
     }
 }

--- a/src/main/java/com/github/cpburnz/minecraft_prometheus_exporter/collectors/Ticks.java
+++ b/src/main/java/com/github/cpburnz/minecraft_prometheus_exporter/collectors/Ticks.java
@@ -6,7 +6,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.Nullable;
 
-import cpw.mods.fml.common.Mod;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.WorldProvider;
 


### PR DESCRIPTION
We exit the initialization before loading the configuration, so the file is never created and we launch with an empty hostname when starting a SP world.

This PR allows running the exporter in SP worlds, but is disabled on startup of SP (still enabled on startup of Dedicated Servers), but allows enabling with commands.